### PR TITLE
Bumped conda reqs bpemb package version to 0.3.6 to match CPU env

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -174,7 +174,7 @@ dependencies:
       - base58==2.0.1
       - beir==2.0.0
       - bottleneck==1.3.6
-      - bpemb==0.3.4
+      - bpemb==0.3.6
       - cachetools==5.3.2
       - constantly==23.10.4
       - datasets==2.19.2


### PR DESCRIPTION
Due to a bug in older versions of the `bpemb` package re downloading gzip'd embeddings, documented here:

https://github.com/bheinzerling/bpemb/issues/66

The conda GPU-capable environment was failing.  Requires a purge of `bpemb` cache files after update to download embedding bin files in correct format.